### PR TITLE
turn off rule no-dupe-class-members

### DIFF
--- a/default-ts.json
+++ b/default-ts.json
@@ -182,7 +182,7 @@
       }
     ],
     "no-continue": "off",
-    "no-dupe-class-members": "warn",
+    "no-dupe-class-members": "off",
     "no-else-return": "warn",
     "no-empty-function": "off",
     "no-nested-ternary": "warn",


### PR DESCRIPTION
no-dupe-class-members was left on "warn" interfering with the TS variant of the same rule